### PR TITLE
게시판 API 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -19,6 +19,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j:8.0.31'

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -29,7 +29,7 @@ public class Article extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @Column(nullable = false) private String title;    // 제목
+    @Setter @Column(nullable = false) private String title;  // 제목
     @Setter @Column(nullable = false, length = 10000) private String content;  // 본문
 
     @Setter private String hashtag;  // 해시태그

--- a/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/project-board/src/main/resources/application.yml
+++ b/project-board/src/main/resources/application.yml
@@ -21,6 +21,9 @@ spring:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
 
 ---
 

--- a/project-board/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
+++ b/project-board/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
@@ -1,0 +1,82 @@
+package com.fastcampus.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // when & then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+        // Given
+
+        // when & then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromAtricle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // when & then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // Given
+
+        // when & then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        // Given
+
+        // when & then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api 들의 존재 여부만 확인하도록 통합테스트 작성 