### PR TITLE
엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 수정

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -52,11 +52,11 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -40,12 +40,12 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }
 

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
@@ -23,18 +23,18 @@ public class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt; // 생성일시
+    protected LocalDateTime createdAt; // 생성일시
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 100)
-    private String createdBy;  // 생성자
+    protected String createdBy;  // 생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt; // 수정일시
+    protected LocalDateTime modifiedAt; // 수정일시
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy; // 수정자
+    protected String modifiedBy; // 수정자
 }

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -8,7 +8,7 @@ import javax.persistence.*;
 import java.util.Objects;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 @Table(indexes = {
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
@@ -28,16 +28,22 @@ public class UserAccount extends AuditingFields{
 
     protected UserAccount() {}
 
-    private UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
+    private UserAccount(String userId, String userPassword, String email, String nickname, String memo, String createdBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.email = email;
         this.nickname = nickname;
         this.memo = memo;
+        this.createdBy = createdBy;
+        this.modifiedBy = createdBy;
     }
 
     public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
-        return new UserAccount(userId, userPassword, email, nickname, memo);
+        return new UserAccount(userId, userPassword, email, nickname, memo, null);
+    }
+
+    public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo, String createdBy) {
+        return new UserAccount(userId, userPassword, email, nickname, memo, createdBy);
     }
 
     @Override

--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -50,11 +50,11 @@ public class UserAccount extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.userId);
+        return this.getUserId() != null && this.getUserId().equals(that.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }

--- a/project-board/src/main/resources/application.yml
+++ b/project-board/src/main/resources/application.yml
@@ -27,6 +27,17 @@ spring:
     detection-strategy: annotated
   thymeleaf3:
     decoupled-logic: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            clientId: "${OAUTH2_CLIENT_ID}"
+            clientSecret: "${OAUTH2_CLIENT_PW}"
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            scope:
+              - email
+              - profile
 
 
 ---


### PR DESCRIPTION
엔티티의 equals(), hashcode()가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #52